### PR TITLE
:sparkles: A read_geotiff function for reading GeoTIFF into ndarray

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
           distro: ubuntu22.04
           githubToken: ${{ github.token }}
           install: |
-            apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
-            apt build-dep numpy
+            apt update
+            apt install -y --no-install-recommends \
+                        gcc g++ gfortran libopenblas-dev liblapack-dev pkg-config \
+                        python3-pip python3-dev
             pip3 install -U pip pytest
           run: |
             set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           install: |
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip
+            apt build-dep numpy
             pip3 install -U pip pytest
           run: |
             set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
           install: |
             apt update
             apt install -y --no-install-recommends \
-                        gcc g++ gfortran libopenblas-dev liblapack-dev pkg-config \
-                        python3-pip python3-dev
+                        gcc g++ gfortran libopenblas-dev liblapack-dev ninja-build \
+                        pkg-config python3-pip python3-dev
             pip3 install -U pip pytest
           run: |
             set -e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +39,7 @@ dependencies = [
  "ndarray",
  "numpy",
  "pyo3",
+ "tempfile",
  "tiff",
 ]
 
@@ -44,6 +51,22 @@ checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "flate2"
@@ -78,6 +101,12 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -198,7 +227,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -300,7 +329,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -308,6 +337,19 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "scopeguard"
@@ -339,6 +381,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,18 +422,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -389,10 +467,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -401,10 +491,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -413,13 +515,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "cog3pio"
 version = "0.1.0"
 dependencies = [
+ "ndarray",
  "pyo3",
  "tiff",
 ]
@@ -88,6 +89,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +114,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -220,6 +271,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "cog3pio"
 version = "0.1.0"
 dependencies = [
  "ndarray",
+ "numpy",
  "pyo3",
  "tiff",
 ]
@@ -154,6 +155,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -286,6 +302,12 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +31,26 @@ name = "cog3pio"
 version = "0.1.0"
 dependencies = [
  "pyo3",
+ "tiff",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -38,6 +64,12 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "libc"
@@ -62,6 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -219,6 +260,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +281,12 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ndarray = "0.15.6"
+numpy = "0.20.0"
 pyo3 = { version = "0.20.3", features = ["abi3-py310"] }
 tiff = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 [dependencies]
 ndarray = "0.15.6"
 numpy = "0.20.0"
-pyo3 = { version = "0.20.3", features = ["abi3-py310"] }
+pyo3 = { version = "0.20.3", features = ["abi3-py310", "extension-module"] }
 tiff = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ name = "cog3pio"
 crate-type = ["cdylib"]
 
 [dependencies]
+ndarray = "0.15.6"
 pyo3 = { version = "0.20.3", features = ["abi3-py310"] }
 tiff = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ ndarray = "0.15.6"
 numpy = "0.20.0"
 pyo3 = { version = "0.20.3", features = ["abi3-py310", "extension-module"] }
 tiff = "0.9.1"
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.20.3", features = ["abi3-py310"] }
+tiff = "0.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: MIT License",
 ]
+dependencies = [
+    "numpy>=1.23",
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/python/cog3pio/__init__.py
+++ b/python/cog3pio/__init__.py
@@ -4,7 +4,7 @@ cog3pio - Cloud-optimized GeoTIFF ... Parallel I/O
 
 from importlib.metadata import version
 
-from .cog3pio import *
+from .cog3pio import read_geotiff
 
 __doc__ = cog3pio.__doc__
 __version__ = version("cog3pio")  # e.g. 0.1.2.dev3+g0ab3cd78

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -1,0 +1,32 @@
+"""
+Test I/O on GeoTIFF files.
+"""
+import tempfile
+import urllib.request
+import os
+import pytest
+
+from cog3pio import read_geotiff
+
+
+@pytest.fixture(scope="module", name="geotiff_path")
+def fixture_geotiff_path():
+    """
+    Filepath to a sample single-band GeoTIFF file.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        geotiff_path = os.path.join(tmpdir, "float32.tif")
+        urllib.request.urlretrieve(
+            url="https://github.com/pka/georaster/raw/v0.1.0/data/tiff/float32.tif",
+            filename=geotiff_path,
+        )
+        yield geotiff_path
+
+
+def test_read_geotiff(geotiff_path):
+    """
+    Read a GeoTIFF file from a local file path.
+    """
+    array = read_geotiff(path=geotiff_path)
+    assert array.shape == (20, 20)
+    assert array.dtype == "float32"

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -1,13 +1,12 @@
-use ndarray::{Array2, ShapeError};
-use std::fs::File;
+use std::io::{Read, Seek};
 
+use ndarray::{Array2, ShapeError};
 use tiff::decoder::{DecodingResult, Limits};
 
 /// Read a GeoTIFF file to an [`ndarray::Array`]
-pub fn read_geotiff(path: &str) -> Result<Array2<f32>, ShapeError> {
-    // Open TIFF file with decoder
-    let file = File::open(path).expect("Cannot find GeoTIFF file");
-    let mut decoder = tiff::decoder::Decoder::new(file).expect("Cannot create tiff decoder");
+pub fn read_geotiff<R: Read + Seek>(stream: R) -> Result<Array2<f32>, ShapeError> {
+    // Open TIFF stream with decoder
+    let mut decoder = tiff::decoder::Decoder::new(stream).expect("Cannot create tiff decoder");
     decoder = decoder.with_limits(Limits::unlimited());
 
     // Get image dimensions

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek};
 use ndarray::{Array2, ShapeError};
 use tiff::decoder::{DecodingResult, Limits};
 
-/// Read a GeoTIFF file to an [`ndarray::Array`]
+/// Synchronously read a GeoTIFF file into an [`ndarray::Array`]
 pub fn read_geotiff<R: Read + Seek>(stream: R) -> Result<Array2<f32>, ShapeError> {
     // Open TIFF stream with decoder
     let mut decoder = tiff::decoder::Decoder::new(stream).expect("Cannot create tiff decoder");
@@ -29,10 +29,11 @@ pub fn read_geotiff<R: Read + Seek>(stream: R) -> Result<Array2<f32>, ShapeError
 #[cfg(test)]
 mod tests {
     use std::io::{Seek, SeekFrom};
+
     use tempfile::tempfile;
+    use tiff::encoder::{colortype, TiffEncoder};
 
     use crate::io::geotiff::read_geotiff;
-    use tiff::encoder::{colortype, TiffEncoder};
 
     #[test]
     fn test_read_geotiff() {
@@ -51,9 +52,9 @@ mod tests {
         bigtiff
             .write_image::<colortype::Gray32Float>(20, 20, &image_data)
             .unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
 
         // Read a BigTIFF file
-        file.seek(SeekFrom::Start(0)).unwrap();
         let arr = read_geotiff(file).unwrap();
         assert_eq!(arr.dim(), (20, 20));
         assert_eq!(arr.mean(), Some(19.0));

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -1,0 +1,28 @@
+use ndarray::{Array2, ShapeError};
+use std::fs::File;
+
+use tiff::decoder::{DecodingResult, Limits};
+
+/// Read a GeoTIFF file to an [`ndarray::Array`]
+pub fn read_geotiff(path: &str) -> Result<Array2<f32>, ShapeError> {
+    // Open TIFF file with decoder
+    let file = File::open(path).expect("Cannot find GeoTIFF file");
+    let mut decoder = tiff::decoder::Decoder::new(file).expect("Cannot create tiff decoder");
+    decoder = decoder.with_limits(Limits::unlimited());
+
+    // Get image dimensions
+    let dimensions: (u32, u32) = decoder.dimensions().expect("Cannot parse image dimensions");
+    let width = dimensions.0 as usize;
+    let height = dimensions.1 as usize;
+
+    // Get image pixel data
+    let DecodingResult::F32(img_data) = decoder.read_image().expect("Cannot decode tiff image")
+    else {
+        panic!("Cannot read band data")
+    };
+
+    // Put image pixel data into an ndarray
+    let vec_data = Array2::from_shape_vec((height, width), img_data)?;
+
+    Ok(vec_data)
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,2 @@
+//! Read and write to GeoTIFF files
+pub mod geotiff;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,2 +1,2 @@
-//! Read and write to GeoTIFF files
+/// Read and write GeoTIFF files
 pub mod geotiff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! A reader for [Cloud Optimized GeoTIFF (COG)](https://www.cogeo.org) files.
 pub mod io;
+use std::fs::File;
 
 use ndarray::Dim;
 use numpy::{PyArray, ToPyArray};
@@ -23,8 +24,10 @@ fn read_geotiff_py<'py>(
     path: &str,
     py: Python<'py>,
 ) -> PyResult<&'py PyArray<f32, Dim<[usize; 2]>>> {
+    // Open TIFF file from path
+    let file = File::open(path).expect("Cannot find GeoTIFF file");
     // Get image pixel data as an ndarray
-    let vec_data = io::geotiff::read_geotiff(path).expect("Cannot read GeoTIFF");
+    let vec_data = io::geotiff::read_geotiff(file).expect("Cannot read GeoTIFF");
     // Convert from ndarray (Rust) to numpy ndarray (Python)
     Ok(vec_data.to_pyarray(py))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,39 @@
-use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
+//! A reader for [Cloud Optimized GeoTIFF (COG)](https://www.cogeo.org) files.
+pub mod io;
 
-/// A Python module implemented in Rust.
+use ndarray::Dim;
+use numpy::{PyArray, ToPyArray};
+use pyo3::prelude::{pyfunction, pymodule, PyModule, PyResult, Python};
+use pyo3::wrap_pyfunction;
+
+/// Read a GeoTIFF file from a path on disk into an ndarray
+///
+/// Parameters
+/// ----------
+/// path : str
+///     The path to the file.
+///
+/// Returns
+/// -------
+/// array : np.ndarray
+///     2D array containing the GeoTIFF pixel data.
+#[pyfunction]
+#[pyo3(name = "read_geotiff")]
+fn read_geotiff_py<'py>(
+    path: &str,
+    py: Python<'py>,
+) -> PyResult<&'py PyArray<f32, Dim<[usize; 2]>>> {
+    // Get image pixel data as an ndarray
+    let vec_data = io::geotiff::read_geotiff(path).expect("Cannot read GeoTIFF");
+    // Convert from ndarray (Rust) to numpy ndarray (Python)
+    Ok(vec_data.to_pyarray(py))
+}
+
+/// A Python module implemented in Rust. The name of this function must match
+/// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
+/// import the module.
 #[pymodule]
 fn cog3pio(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(read_geotiff_py, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,17 @@
+#![warn(missing_docs)]
+//! # Cloud-optimized GeoTIFF ... Parallel I/O
+//!
 //! A reader for [Cloud Optimized GeoTIFF (COG)](https://www.cogeo.org) files.
+//!
+//! Uses [`tiff`] to decode TIFF images, storing the pixel data in [`ndarray`] structs.
+//!
+//! **Note**: For Python users, there are also bindings (via [`pyo3`]) to read GeoTIFF files into
+//! `numpy.ndarray` objects (i.e. similar to [`rasterio`](https://github.com/rasterio/rasterio)).
+//! This is done via the [`numpy`] crate which enables passing data from Rust to Python.
+
+/// Modules for handling Input/Output of GeoTIFF data
 pub mod io;
+
 use std::fs::File;
 
 use ndarray::Dim;


### PR DESCRIPTION
Rust-based function for reading GeoTIFF files!

Uses the [`tiff`](https://docs.rs/tiff/0.9.1/tiff/index.html) crate for the I/O, [`ndarray`](https://docs.rs/ndarray/0.15.6/ndarray/index.html) crate to store the 2D array in Rust, and [`numpy`](https://docs.rs/numpy/0.20.0/numpy/index.html) crate to convert to numpy.ndarray in Python.

**Note**: This only works on single-band GeoTIFF files with float32 dtype for now

Usage:

In Rust:

```rust
use ndarray::Array2;
use std::fs::File;
use cog3pio::io::geotiff::read_geotiff;

let path: &str = "path/to/file.tif";
let file: File = File::open(path).expect("Cannot find GeoTIFF file");
let arr: Array2<f32> = read_geotiff(file).unwrap();
assert_eq!(arr.dim(), (20, 20));
assert_eq!(arr.mean(), Some(19.0));
```

In Python:

```python
import numpy as np
from cog3pio import read_geotiff

array : np.ndarray = read_geotiff(path="georaster/data/tiff/float32.tif")
assert array.shape == (20, 20)
assert array.dtype == "float32"
```

TODO:
- [x] Initial implementation to allow reading single-band Float32 dtype GeoTIFF files
- [x] Improve documentation
- [x] Add unit tests in Python and Rust

TODO in future:
- [ ] Refactor to handle other dtypes
- [ ] Reconsider project layout?

References:
- https://stackoverflow.com/questions/76145217/how-to-transform-a-tiff-file-to-ndarray-in-rust
- https://en.anyquestion.info/q/how-to-transform-a-tiff-file-to-ndarray-in-rust
- https://github.com/image-rs/image-tiff/pull/216/files