### PR TITLE
:construction_worker: Setup benchmark workflow with pytest-codspeed

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,8 +16,7 @@ on:
   # performance analysis in order to generate initial data.
   workflow_dispatch:
   release:
-    types:
-      - published
+    types: [ published ]
 
 jobs:
   benchmarks:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,60 @@
+# Run performance benchmarks
+#
+# Continuous benchmarking using pytest-codspeed. Measures the execution speed
+# of tests marked with @pytest.mark.benchmark decorator.
+
+name: Benchmarks
+
+on:
+  # Run on pushes to the main branch
+  push:
+    branches: [ main ]
+  # Run on pull requests
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      # Checkout current git repository
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+      # Setup Python interpreter
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+        with:
+          python-version: '3.12'
+
+      # Build binary distribution wheel
+      - name: Build wheels
+        uses: PyO3/maturin-action@60d11847b29f81ca5375519a8eb33cc336ba4bfa  # v1.41.0
+        with:
+          target: x86_64
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+
+      # Install the package that we want to test
+      - name: Install the package
+        run: |
+          set -e
+          python -m pip install cog3pio[tests] --find-links dist --force-reinstall
+          python -m pip list
+
+      # Run the benchmark tests
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@2e04019f4572c19684929a755da499f19a00b25b  # v2.2.1
+        with:
+          run: |
+            python -m pytest --verbose --codspeed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
   push:
     branches: [ "main" ]
   release:
-    types: [published]
+    types: [ published ]
   pull_request:
-    types: [opened, ready_for_review, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
     branches: [ "main" ]
 
 permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 tests = [
     "pytest",
+    "pytest-codspeed",
 ]
 
 [tool.maturin]

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -23,6 +23,7 @@ def fixture_geotiff_path():
         yield geotiff_path
 
 
+@pytest.mark.benchmark
 def test_read_geotiff(geotiff_path):
     """
     Read a GeoTIFF file from a local file path.

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -24,7 +24,7 @@ def fixture_geotiff_path():
 
 
 @pytest.mark.benchmark
-def test_read_geotiff(geotiff_path):
+def test_read_geotiff_local(geotiff_path):
     """
     Read a GeoTIFF file from a local file path.
     """


### PR DESCRIPTION
Measuring the execution speed of unit tests to track performance of cog3pio Python functions over time.

Using [`pytest-codspeed`](https://github.com/CodSpeedHQ/pytest-codspeed) to do the benchmarking, with the help of https://github.com/CodSpeedHQ/action. Decorated `test_read_geotiff` with `@pytest.mark.benchmark` to see if the benchmarking works.

Note: Running the benchmarks on Python 3.12 to enable flame graph generation, available with [`pytest-codspeed>=2.0.0`](https://github.com/CodSpeedHQ/pytest-codspeed/releases/tag/v2.0.0) - see https://docs.codspeed.io/features/trace-generation.

References:
- https://codspeed.io/blog/introducing-codspeed
- https://docs.codspeed.io/benchmarks/python#running-the-benchmarks-in-your-ci