### PR TITLE
:recycle: Refactor unit test to be non-square

### DIFF
--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -49,16 +49,16 @@ mod tests {
         let mut file = tempfile().unwrap();
         let mut bigtiff = TiffEncoder::new_big(&mut file).unwrap();
         bigtiff
-            .write_image::<colortype::Gray32Float>(10, 20, &image_data) // width, height, data
+            .write_image::<colortype::Gray32Float>(20, 10, &image_data) // width, height, data
             .unwrap();
         file.seek(SeekFrom::Start(0)).unwrap();
 
         // Read a BigTIFF file
         let arr = read_geotiff(file).unwrap();
         assert_eq!(arr.ndim(), 2);
-        assert_eq!(arr.dim(), (20, 10)); // (height, width)
-        assert_eq!(arr.nrows(), 20); // y-axis
-        assert_eq!(arr.ncols(), 10); // x-axis
+        assert_eq!(arr.dim(), (10, 20)); // (height, width)
+        assert_eq!(arr.nrows(), 10); // y-axis
+        assert_eq!(arr.ncols(), 20); // x-axis
         assert_eq!(arr.mean(), Some(14.0));
     }
 }

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -11,7 +11,7 @@ pub fn read_geotiff<R: Read + Seek>(stream: R) -> Result<Array2<f32>, TiffError>
     decoder = decoder.with_limits(Limits::unlimited());
 
     // Get image dimensions
-    let (height, width): (u32, u32) = decoder.dimensions()?;
+    let (width, height): (u32, u32) = decoder.dimensions()?;
 
     // Get image pixel data
     let DecodingResult::F32(img_data) = decoder.read_image()? else {
@@ -49,16 +49,16 @@ mod tests {
         let mut file = tempfile().unwrap();
         let mut bigtiff = TiffEncoder::new_big(&mut file).unwrap();
         bigtiff
-            .write_image::<colortype::Gray32Float>(20, 10, &image_data)
+            .write_image::<colortype::Gray32Float>(10, 20, &image_data) // width, height, data
             .unwrap();
         file.seek(SeekFrom::Start(0)).unwrap();
 
         // Read a BigTIFF file
         let arr = read_geotiff(file).unwrap();
         assert_eq!(arr.ndim(), 2);
-        assert_eq!(arr.dim(), (20, 10));  // (height, width)
-        assert_eq!(arr.nrows(), 20);  // y-axis
-        assert_eq!(arr.ncols(), 10);  // x-axis
+        assert_eq!(arr.dim(), (20, 10)); // (height, width)
+        assert_eq!(arr.nrows(), 20); // y-axis
+        assert_eq!(arr.ncols(), 10); // x-axis
         assert_eq!(arr.mean(), Some(14.0));
     }
 }


### PR DESCRIPTION
~Classic mistake of getting the wrong order when mixing geographic xy with image yx. Corrected to use y (height), x (width) order, and updated unit test to be non-square so that this won't happen again.~

Edit: Actually, the code was correct, just me getting confused because the `tiff` crate uses (width, height), whereas `ndarray` crate uses (height, width). So just refactoring the unit test to use a non-square TIFF.

References:
- https://docs.rs/ndarray/0.15.6/ndarray/struct.ArrayBase.html#method.ncols

Patches #3