### PR TITLE
:recycle: Refactor to return 3D arrays of shape (band, height, width)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ use std::io::Cursor;
 
 use bytes::Bytes;
 use cog3pio::io::geotiff::read_geotiff;
-use ndarray::Array2;
+use ndarray::Array3;
 use object_store::path::Path;
 use object_store::{parse_url, GetResult, ObjectStore};
 use tokio;
@@ -53,9 +53,9 @@ async fn main() {
         Cursor::new(bytes)
     };
 
-    let arr: Array2<f32> = read_geotiff(stream).unwrap();
-    assert_eq!(arr.dim(), (549, 549));
-    assert_eq!(arr[[500, 500]], 0.13482364);
+    let arr: Array3<f32> = read_geotiff(stream).unwrap();
+    assert_eq!(arr.dim(), (1, 549, 549));
+    assert_eq!(arr[[0, 500, 500]], 0.13482364);
 }
 ```
 
@@ -68,7 +68,7 @@ from cog3pio import read_geotiff
 array: np.ndarray = read_geotiff(
     path="https://github.com/cogeotiff/rio-tiler/raw/6.4.0/tests/fixtures/cog_nodata_nan.tif"
 )
-assert array.shape == (549, 549)
+assert array.shape == (1, 549, 549)  # bands, height, width
 assert array.dtype == "float32"
 ```
 

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -31,7 +31,7 @@ def test_read_geotiff_local(geotiff_path):
     Read a GeoTIFF file from a local file path.
     """
     array = read_geotiff(path=geotiff_path)
-    assert array.shape == (20, 20)
+    assert array.shape == (1, 20, 20)
     assert array.dtype == "float32"
 
 
@@ -43,7 +43,7 @@ def test_read_geotiff_remote():
     array = read_geotiff(
         path="https://github.com/pka/georaster/raw/v0.1.0/data/tiff/float32.tif"
     )
-    assert array.shape == (20, 20)
+    assert array.shape == (1, 20, 20)
     assert array.dtype == "float32"
 
 

--- a/src/python/adapters.rs
+++ b/src/python/adapters.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use bytes::Bytes;
-use numpy::{PyArray2, ToPyArray};
+use numpy::{PyArray3, ToPyArray};
 use object_store::{parse_url, ObjectStore};
 use pyo3::exceptions::{PyBufferError, PyFileNotFoundError, PyValueError};
 use pyo3::prelude::{pyfunction, pymodule, PyModule, PyResult, Python};
@@ -44,7 +44,7 @@ fn path_to_stream(path: &str) -> PyResult<Cursor<Bytes>> {
     Ok(stream)
 }
 
-/// Read a GeoTIFF file from a path on disk into an ndarray
+/// Read a GeoTIFF file from a path on disk or a url into an ndarray
 ///
 /// Parameters
 /// ----------
@@ -64,7 +64,7 @@ fn path_to_stream(path: &str) -> PyResult<Cursor<Bytes>> {
 /// assert array.shape == (20, 20)
 #[pyfunction]
 #[pyo3(name = "read_geotiff")]
-fn read_geotiff_py<'py>(path: &str, py: Python<'py>) -> PyResult<&'py PyArray2<f32>> {
+fn read_geotiff_py<'py>(path: &str, py: Python<'py>) -> PyResult<&'py PyArray3<f32>> {
     // Parse URL into byte stream
     let stream = path_to_stream(path)?;
 


### PR DESCRIPTION
Adding a third dimension (band or channel) to the ndarray output in anticipation of multi-band support. Updated the unit tests to check for the new 3D shape.

Patches original implementatin in #3.