### PR TITLE
:sparkles: Implement PyCogReader struct with new and to_numpy methods

### DIFF
--- a/python/cog3pio/__init__.py
+++ b/python/cog3pio/__init__.py
@@ -4,7 +4,7 @@ cog3pio - Cloud-optimized GeoTIFF ... Parallel I/O
 
 from importlib.metadata import version
 
-from .cog3pio import read_geotiff, CogReader  # noqa: F401
+from .cog3pio import CogReader, read_geotiff  # noqa: F401
 
 __doc__ = cog3pio.__doc__
 __version__ = version("cog3pio")  # e.g. 0.1.2.dev3+g0ab3cd78

--- a/python/cog3pio/__init__.py
+++ b/python/cog3pio/__init__.py
@@ -4,7 +4,7 @@ cog3pio - Cloud-optimized GeoTIFF ... Parallel I/O
 
 from importlib.metadata import version
 
-from .cog3pio import read_geotiff
+from .cog3pio import read_geotiff, CogReader  # noqa: F401
 
 __doc__ = cog3pio.__doc__
 __version__ = version("cog3pio")  # e.g. 0.1.2.dev3+g0ab3cd78

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -81,8 +81,7 @@ def test_read_geotiff_unsupported_dtype():
     """
     with pytest.raises(
         ValueError,
-        match="Cannot read GeoTIFF because: "
-        "The Decoder does not support the image format ",
+        match="The Decoder does not support the image format ",
     ):
         read_geotiff(
             path="https://github.com/corteva/rioxarray/raw/0.15.1/test/test_data/input/cint16.tif"

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -5,9 +5,10 @@ import os
 import tempfile
 import urllib.request
 
+import numpy as np
 import pytest
 
-from cog3pio import read_geotiff
+from cog3pio import CogReader, read_geotiff
 
 
 # %%
@@ -86,3 +87,20 @@ def test_read_geotiff_unsupported_dtype():
         read_geotiff(
             path="https://github.com/corteva/rioxarray/raw/0.15.1/test/test_data/input/cint16.tif"
         )
+
+
+def test_CogReader_data():
+    """
+    Ensure that the CogReader class's `data` method produces a numpy.ndarray output.
+    """
+    reader = CogReader(
+        path="https://github.com/rasterio/rasterio/raw/1.3.9/tests/data/float32.tif"
+    )
+    array = reader.data()
+    assert array.shape == (1, 2, 3)  # band, height, width
+    np.testing.assert_equal(
+        actual=array,
+        desired=np.array(
+            [[[1.41, 1.23, 0.78], [0.32, -0.23, -1.88]]], dtype=np.float32
+        ),
+    )

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -89,14 +89,14 @@ def test_read_geotiff_unsupported_dtype():
         )
 
 
-def test_CogReader_data():
+def test_CogReader_to_numpy():
     """
-    Ensure that the CogReader class's `data` method produces a numpy.ndarray output.
+    Ensure that the CogReader class's `to_numpy` method produces a numpy.ndarray output.
     """
     reader = CogReader(
         path="https://github.com/rasterio/rasterio/raw/1.3.9/tests/data/float32.tif"
     )
-    array = reader.data()
+    array = reader.to_numpy()
     assert array.shape == (1, 2, 3)  # band, height, width
     np.testing.assert_equal(
         actual=array,

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -7,13 +7,14 @@ use tiff::tags::Tag;
 use tiff::{TiffError, TiffFormatError, TiffResult};
 
 /// Cloud-optimized GeoTIFF reader
-struct CogReader<R: Read + Seek> {
-    decoder: Decoder<R>,
+pub(crate) struct CogReader<R: Read + Seek> {
+    /// TIFF decoder
+    pub decoder: Decoder<R>,
 }
 
 impl<R: Read + Seek> CogReader<R> {
     /// Create a new GeoTIFF decoder that decodes from a stream buffer
-    fn new(stream: R) -> TiffResult<Self> {
+    pub fn new(stream: R) -> TiffResult<Self> {
         // Open TIFF stream with decoder
         let mut decoder = Decoder::new(stream)?;
         decoder = decoder.with_limits(Limits::unlimited());
@@ -22,7 +23,7 @@ impl<R: Read + Seek> CogReader<R> {
     }
 
     /// Decode GeoTIFF image to an [`ndarray::Array`]
-    fn ndarray(&mut self) -> TiffResult<Array3<f32>> {
+    pub fn ndarray(&mut self) -> TiffResult<Array3<f32>> {
         // Get image dimensions
         let (width, height): (u32, u32) = self.decoder.dimensions()?;
 
@@ -34,10 +35,10 @@ impl<R: Read + Seek> CogReader<R> {
         };
 
         // Put image pixel data into an ndarray
-        let vec_data = Array3::from_shape_vec((1, height as usize, width as usize), image_data)
+        let array_data = Array3::from_shape_vec((1, height as usize, width as usize), image_data)
             .map_err(|_| TiffFormatError::InvalidDimensions(height, width))?;
 
-        Ok(vec_data)
+        Ok(array_data)
     }
 
     /// Affine transformation for 2D matrix extracted from TIFF tag metadata, used to transform
@@ -96,9 +97,9 @@ pub fn read_geotiff<R: Read + Seek>(stream: R) -> TiffResult<Array3<f32>> {
     let mut reader = CogReader::new(stream)?;
 
     // Decode TIFF into ndarray
-    let vec_data: Array3<f32> = reader.ndarray()?;
+    let array_data: Array3<f32> = reader.ndarray()?;
 
-    Ok(vec_data)
+    Ok(array_data)
 }
 
 #[cfg(test)]

--- a/src/python/adapters.rs
+++ b/src/python/adapters.rs
@@ -60,7 +60,7 @@ impl PyCogReader {
     /// -------
     /// array : np.ndarray
     ///     3D array of shape (band, height, width) containing the GeoTIFF pixel data.
-    fn data<'py>(&mut self, py: Python<'py>) -> PyResult<&'py PyArray3<f32>> {
+    fn to_numpy<'py>(&mut self, py: Python<'py>) -> PyResult<&'py PyArray3<f32>> {
         let array_data: Array3<f32> = self
             .inner
             .ndarray()
@@ -129,7 +129,7 @@ fn read_geotiff_py<'py>(path: &str, py: Python<'py>) -> PyResult<&'py PyArray3<f
     let mut reader = PyCogReader::new(path)?;
 
     // Decode TIFF into numpy ndarray
-    let array_data = reader.data(py)?;
+    let array_data = reader.to_numpy(py)?;
 
     Ok(array_data)
 }

--- a/src/python/adapters.rs
+++ b/src/python/adapters.rs
@@ -12,7 +12,31 @@ use url::Url;
 
 use crate::io::geotiff::CogReader;
 
-/// Python class interface to the Cloud-optimized GeoTIFF reader struct
+/// Python class interface to a Cloud-optimized GeoTIFF reader.
+///
+/// Parameters
+/// ----------
+/// path : str
+///     The path to the file, or a url to a remote file.
+///
+/// Returns
+/// -------
+/// reader : cog3pio.CogReader
+///     A new CogReader instance for decoding GeoTIFF files.
+///
+/// Examples
+/// --------
+/// >>> import numpy as np
+/// >>> from cog3pio import CogReader
+/// >>>
+/// >>> reader = CogReader(
+/// >>>     path="https://github.com/rasterio/rasterio/raw/1.3.9/tests/data/float32.tif"
+/// >>> )
+/// >>> array: np.ndarray = reader.data()
+/// >>> array.shape
+/// >>> (1, 12, 13)
+/// >>> array.dtype
+/// >>> dtype('float32')
 #[pyclass]
 #[pyo3(name = "CogReader")]
 struct PyCogReader {
@@ -31,6 +55,11 @@ impl PyCogReader {
     }
 
     /// Get image pixel data from GeoTIFF as a numpy.ndarray
+    ///
+    /// Returns
+    /// -------
+    /// array : np.ndarray
+    ///     3D array of shape (band, height, width) containing the GeoTIFF pixel data.
     fn data<'py>(&mut self, py: Python<'py>) -> PyResult<&'py PyArray3<f32>> {
         let array_data: Array3<f32> = self
             .inner
@@ -85,7 +114,7 @@ fn path_to_stream(path: &str) -> PyResult<Cursor<Bytes>> {
 /// Returns
 /// -------
 /// array : np.ndarray
-///     2D array containing the GeoTIFF pixel data.
+///     3D array of shape (band, height, width) containing the GeoTIFF pixel data.
 ///
 /// Examples
 /// --------


### PR DESCRIPTION
A (Py)CogReader class for Python that wraps around the CogReader struct!

Usage (Python):

```python
import numpy as np
from cog3pio import CogReader

cog_url: str = (
    "https://github.com/cogeotiff/rio-tiler/raw/6.4.1/tests/fixtures/cog_nodata_nan.tif"
)
reader = CogReader(path=cog_url)

array: np.ndarray = reader.to_numpy()
assert array.shape == (1, 549, 549)  # bands, height, width
```

TODO:
- [x] Initial implementation of new (`__init__`) and `to_numpy` methods
- [x] Add docstrings
- [x] Add unit tests

TODO in the future:
- [ ] Add type hint stubs (best to set up linter CIs first)

P.S. This is a set up for the eventual xarray backend code :wink: