### PR TITLE
:sparkles: Support reading multi-band GeoTIFF files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,8 +1433,7 @@ dependencies = [
 [[package]]
 name = "tiff"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+source = "git+https://github.com/weiji14/image-tiff.git?rev=82c003da13abec42605271805f99ae497fab9649#82c003da13abec42605271805f99ae497fab9649"
 dependencies = [
  "flate2",
  "jpeg-decoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "tiff"
 version = "0.9.1"
-source = "git+https://github.com/weiji14/image-tiff.git?rev=82c003da13abec42605271805f99ae497fab9649#82c003da13abec42605271805f99ae497fab9649"
+source = "git+https://github.com/image-rs/image-tiff.git?rev=0c54a18e2130bd8e3e897009e1fb59eaaf607c6c#0c54a18e2130bd8e3e897009e1fb59eaaf607c6c"
 dependencies = [
  "flate2",
  "jpeg-decoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ndarray = "0.15.6"
 numpy = "0.20.0"
 object_store = { version = "0.9.0", features = ["http"] }
 pyo3 = { version = "0.20.3", features = ["abi3-py310", "extension-module"] }
-tiff = "0.9.1"
+tiff = { git = "https://github.com/weiji14/image-tiff.git", version = "0.9.1", rev = "82c003da13abec42605271805f99ae497fab9649" }  # https://github.com/image-rs/image-tiff/pull/224
 tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
 url = "2.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ndarray = "0.15.6"
 numpy = "0.20.0"
 object_store = { version = "0.9.0", features = ["http"] }
 pyo3 = { version = "0.20.3", features = ["abi3-py310", "extension-module"] }
-tiff = { git = "https://github.com/weiji14/image-tiff.git", version = "0.9.1", rev = "82c003da13abec42605271805f99ae497fab9649" }  # https://github.com/image-rs/image-tiff/pull/224
+tiff = { git = "https://github.com/image-rs/image-tiff.git", version = "0.9.1", rev = "0c54a18e2130bd8e3e897009e1fb59eaaf607c6c" }  # https://github.com/image-rs/image-tiff/pull/224
 tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
 url = "2.5.0"
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ assert array.dtype == "float32"
 Short term (Q1 2024):
 - [ ] Implement single-band GeoTIFF reader to
       [`ndarray`](https://github.com/rust-ndarray/ndarray)
-- [ ] Multi-band reader (relying on
+- [x] Multi-band reader (relying on
       [`image-tiff`](https://github.com/image-rs/image-tiff))
 - [x] Read from remote storage (using
       [`object-store`](https://github.com/apache/arrow-rs/tree/object_store_0.9.0/object_store))

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ assert array.dtype == "float32"
 ```
 
 > [!NOTE]
-> Currently, this crate/library only supports reading single-band float32 GeoTIFF files,
-> i.e. multi-band and other dtypes (e.g. uint16) don't work yet. See roadmap below on
+> Currently, this crate/library only supports reading single or multi-band float32
+> GeoTIFF files, i.e. other dtypes (e.g. uint16) don't work yet. See roadmap below on
 > future plans.
 
 
 ## Roadmap
 
 Short term (Q1 2024):
-- [ ] Implement single-band GeoTIFF reader to
+- [ ] Implement single-band GeoTIFF reader (for uint/int/float dtypes) to
       [`ndarray`](https://github.com/rust-ndarray/ndarray)
 - [x] Multi-band reader (relying on
       [`image-tiff`](https://github.com/image-rs/image-tiff))

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -29,7 +29,7 @@ def fixture_geotiff_path():
 @pytest.mark.benchmark
 def test_read_geotiff_local(geotiff_path):
     """
-    Read a GeoTIFF file from a local file path.
+    Read a single-band GeoTIFF file from a local file path.
     """
     array = read_geotiff(path=geotiff_path)
     assert array.shape == (1, 20, 20)
@@ -39,12 +39,24 @@ def test_read_geotiff_local(geotiff_path):
 @pytest.mark.benchmark
 def test_read_geotiff_remote():
     """
-    Read a GeoTIFF file from a remote URL.
+    Read a single-band GeoTIFF file from a remote URL.
     """
     array = read_geotiff(
         path="https://github.com/pka/georaster/raw/v0.1.0/data/tiff/float32.tif"
     )
     assert array.shape == (1, 20, 20)
+    assert array.dtype == "float32"
+
+
+@pytest.mark.benchmark
+def test_read_geotiff_multi_band():
+    """
+    Read a multi-band GeoTIFF file from a remote URL.
+    """
+    array = read_geotiff(
+        path="https://github.com/locationtech/geotrellis/raw/v3.7.1/raster/data/one-month-tiles-multiband/result.tif"
+    )
+    assert array.shape == (2, 512, 512)
     assert array.dtype == "float32"
 
 

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -87,6 +87,21 @@ def test_read_geotiff_missing_url():
         read_geotiff(path="https://example.com/geo.tif")
 
 
+def test_read_geotiff_unsupported_colortype():
+    """
+    Check that a ValueError is raised when an unsupported GeoTIFF (with ColorType::RGB)
+    is passed to read_geotiff.
+    """
+    with pytest.raises(
+        ValueError,
+        match="The Decoder does not support the image format "
+        r"`RGBPalette with \[8\] bits per sample is unsupported",
+    ):
+        read_geotiff(
+            path="https://github.com/GenericMappingTools/gmtserver-admin/raw/caf0dbd015f0154687076dd31dc8baff62c95040/cache/earth_day_HD.tif"
+        )
+
+
 def test_read_geotiff_unsupported_dtype():
     """
     Check that a ValueError is raised when an unsupported GeoTIFF (of ComplexInt16 type)
@@ -94,7 +109,8 @@ def test_read_geotiff_unsupported_dtype():
     """
     with pytest.raises(
         ValueError,
-        match="The Decoder does not support the image format ",
+        match="The Decoder does not support the image format "
+        r"`Sample format \[Unknown\(5\)\] is unsupported",
     ):
         read_geotiff(
             path="https://github.com/corteva/rioxarray/raw/0.15.1/test/test_data/input/cint16.tif"

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -4,7 +4,7 @@ use geo::AffineTransform;
 use ndarray::Array3;
 use tiff::decoder::{Decoder, DecodingResult, Limits};
 use tiff::tags::Tag;
-use tiff::{TiffError, TiffFormatError, TiffResult};
+use tiff::{ColorType, TiffError, TiffFormatError, TiffResult};
 
 /// Cloud-optimized GeoTIFF reader
 pub(crate) struct CogReader<R: Read + Seek> {
@@ -34,9 +34,21 @@ impl<R: Read + Seek> CogReader<R> {
             _ => unimplemented!("Data types other than float32 are not yet supported."),
         };
 
+        // Count number of bands
+        let color_type = self.decoder.colortype()?;
+        let num_bands: usize = match color_type {
+            ColorType::Multiband {
+                bit_depth: _,
+                num_samples,
+            } => num_samples as usize,
+            ColorType::Gray(_) => 1,
+            _ => unimplemented!("{color_type:?} is not yet supported"),
+        };
+
         // Put image pixel data into an ndarray
-        let array_data = Array3::from_shape_vec((1, height as usize, width as usize), image_data)
-            .map_err(|_| TiffFormatError::InvalidDimensions(height, width))?;
+        let array_data =
+            Array3::from_shape_vec((num_bands, height as usize, width as usize), image_data)
+                .map_err(|_| TiffFormatError::InconsistentSizesEncountered)?;
 
         Ok(array_data)
     }
@@ -142,6 +154,24 @@ mod tests {
         assert_eq!(first_band.nrows(), 10); // y-axis
         assert_eq!(first_band.ncols(), 20); // x-axis
         assert_eq!(arr.mean(), Some(14.0));
+    }
+
+    #[tokio::test]
+    async fn test_read_geotiff_multi_band() {
+        let cog_url: &str =
+            "https://github.com/locationtech/geotrellis/raw/v3.7.1/raster/data/one-month-tiles-multiband/result.tif";
+        let tif_url = Url::parse(cog_url).unwrap();
+        let (store, location) = parse_url(&tif_url).unwrap();
+
+        let result = store.get(&location).await.unwrap();
+        let bytes = result.bytes().await.unwrap();
+        let stream = Cursor::new(bytes);
+
+        let mut reader = CogReader::new(stream).unwrap();
+        let array = reader.ndarray().unwrap();
+
+        assert_eq!(array.dim(), (2, 512, 512));
+        assert_eq!(array.mean(), Some(225.17654));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Count the number of bands or channels in the GeoTIFF file when decoding by looking at [`ColorType`](https://docs.rs/tiff/0.9.1/tiff/enum.ColorType.html).

Note that this relies on a patch to `image-tiff` that has been submitted as a pull request at https://github.com/image-rs/image-tiff/pull/224

TODO:
- [x] Initial implementation and unit test
- [x] Add more unit tests on Python side
- [x] Refactor once https://github.com/image-rs/image-tiff/pull/224 is merged
- [x] Improve error messaging