### PR TITLE
:construction_worker: Setup CI job matrix to run cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,25 @@ on:
     types: [ opened, reopened, synchronize ]
     branches: [ "main" ]
 
+env:
+  CARGO_TERM_COLOR: always
+
 permissions:
   contents: read
 
 jobs:
+  cargo:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+    - name: Build
+      run: cargo build --verbose
+
+    - name: Run tests
+      run: cargo test --verbose
+
   linux:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,20 @@ permissions:
   contents: read
 
 jobs:
-  cargo:
+  rust:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+
+    - name: Update Rust toolchain
+      run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
 
     - name: Build
       run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "cog3pio"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bytes = "1.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! use bytes::Bytes;
 //! use cog3pio::io::geotiff::read_geotiff;
-//! use ndarray::Array2;
+//! use ndarray::Array3;
 //! use object_store::path::Path;
 //! use object_store::{parse_url, GetResult, ObjectStore};
 //! use tokio;
@@ -38,9 +38,9 @@
 //!         Cursor::new(bytes)
 //!     };
 //!
-//!     let arr: Array2<f32> = read_geotiff(stream).unwrap();
-//!     assert_eq!(arr.dim(), (549, 549));
-//!     assert_eq!(arr[[500, 500]], 0.13482364);
+//!     let arr: Array3<f32> = read_geotiff(stream).unwrap();
+//!     assert_eq!(arr.dim(), (1, 549, 549));
+//!     assert_eq!(arr[[0, 500, 500]], 0.13482364);
 //! }
 //! ```
 


### PR DESCRIPTION
Ensure that Rust unit tests and doctests are checked too. Running on Ubuntu-24.04.

TODO:
- [x] Initial CI setup
- [x] Test on Rust stable, beta and nightly
- [x] Get `cargo test --doc` to work

References:
- https://doc.rust-lang.org/cargo/guide/continuous-integration.html#github-actions
- https://stackoverflow.com/questions/78204333/how-to-run-rust-library-unit-tests-with-maturin/78209153#78209153
- https://users.rust-lang.org/t/how-to-run-only-the-doctests/54048/2