### PR TITLE
:sparkles: Support reading uint/int/float dtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "bytes",
  "geo",
  "ndarray",
+ "num-traits",
  "numpy",
  "object_store",
  "pyo3",
@@ -770,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 bytes = "1.5.0"
 geo = { git = "https://github.com/georust/geo.git", version = "0.28.0", rev = "481196b4e50a488442b3919e02496ad909fc5412" }
 ndarray = "0.15.6"
+num-traits = "0.2.19"
 numpy = "0.21.0"
 object_store = { version = "0.9.0", features = ["http"] }
 pyo3 = { version = "0.21.1", features = ["abi3-py310", "extension-module"] }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ async fn main() {
     };
 
     // Read GeoTIFF into an ndarray::Array
-    let arr: Array3<f32> = read_geotiff(stream).unwrap();
+    let arr: Array3<f32> = read_geotiff::<f32, _>(stream).unwrap();
     assert_eq!(arr.dim(), (1, 549, 549));
     assert_eq!(arr[[0, 500, 500]], 0.13482364);
 }

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ assert dataarray.dtype == "float32"
 ```
 
 > [!NOTE]
-> Currently, this crate/library only supports reading single or multi-band float32
-> GeoTIFF files, i.e. other dtypes (e.g. uint16) don't work yet. See roadmap below on
-> future plans.
+> Currently, the Python library supports reading single or multi-band GeoTIFF files into
+> a float32 array only, i.e. other dtypes (e.g. uint16) don't work yet. There is support
+> for reading into different dtypes in the Rust crate via a turbofish operator though!
 
 
 ## Roadmap
@@ -104,19 +104,20 @@ Short term (Q1 2024):
 - [x] Read from HTTP remote storage (using
       [`object-store`](https://github.com/apache/arrow-rs/tree/object_store_0.9.0/object_store))
 
-Medium term (Q2 2024):
+Medium term (Q2-Q4 2024):
 - [x] Integration with `xarray` as a
       [`BackendEntrypoint`](https://docs.xarray.dev/en/v2024.02.0/internals/how-to-add-new-backend.html)
-- [ ] Implement single-band GeoTIFF reader for multiple dtypes (uint/int/float) (relying
-      on [`geotiff`](https://github.com/georust/geotiff) crate)
+- [x] Implement single-band GeoTIFF reader for multiple dtypes (uint/int/float) (based
+      on [`geotiff`](https://github.com/georust/geotiff) crate, Rust-only)
 
-Longer term (Q3-Q4 2024):
+Longer term (2025):
 - [ ] Parallel reader (TBD on multi-threaded or asynchronous)
 - [ ] Direct-to-GPU loading
 
 
 ## Related crates
 
+- https://github.com/developmentseed/aiocogeo-rs
 - https://github.com/georust/geotiff
 - https://github.com/jblindsay/whitebox-tools
 - https://github.com/pka/georaster

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,16 @@
 //!         Cursor::new(bytes)
 //!     };
 //!
-//!     let arr: Array3<f32> = read_geotiff(stream).unwrap();
+//!     let arr: Array3<f32> = read_geotiff::<f32, _>(stream).unwrap();
 //!     assert_eq!(arr.dim(), (1, 549, 549));
 //!     assert_eq!(arr[[0, 500, 500]], 0.13482364);
 //! }
 //! ```
+//!
+//! Note that the output dtype can be specified either by using a type hint
+//! (`let arr: Array3<f32>`) or via the turbofish operator (`read_geotiff::<f32>`).
+//! Currently supported dtypes include uint (u8/u16/u32/u64), int (i8/i16/i32/i64) and
+//! float (f32/f64).
 
 /// Modules for handling Input/Output of GeoTIFF data
 pub mod io;


### PR DESCRIPTION
Finally figured out how to workaround the strict typing to support different dtypes after looking at https://github.com/georust/geotiff/pull/17! Using a [trait bound](https://doc.rust-lang.org/reference/trait-bounds.html#trait-and-lifetime-bounds) to handle this, specifically [`num_traits::FromPrimitive`](https://docs.rs/num-traits/latest/num_traits/cast/trait.FromPrimitive.html).

Notes:
- This is only implemented on the Rust side for now, because PyO3 doesn't work with generic parameters (https://pyo3.rs/v0.22.2/class.html#no-generic-parameters) and I haven't figured out macros yet.
- Longer term, I'd still like to delegate most of this logic to the georust/geotiff crate. Putting it here for now, more as a chance for me to learn about tricky Rust concepts.

TODO:
- [x] Initial implementation to support u8/u16/u32/u64/i8/i16/i32/i64/f32/f64 dtypes
- [x] Update roadmap in main README.md
- [x] Document multi-dtype usage in main README.md and `src/lib.rs` crate-level docs
