### PR TITLE
:rotating_light: Setup CI to run linting using cargo clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+# Run linters
+#
+# Lint Rust code using cargo clippy. Apply static analysis rules to catch common
+# mistakes and improves code style.
+
+name: Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: ["main"]
+
+# Make sure CI fails on all warnings, including Clippy lints
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features

--- a/python/cog3pio/xarray_backend.py
+++ b/python/cog3pio/xarray_backend.py
@@ -31,7 +31,7 @@ class Cog3pioBackendEntrypoint(BackendEntrypoint):
     ) -> xr.Dataset:
         reader = CogReader(path=filename_or_obj)
 
-        array: np.ndarray = reader.to_numpy()
+        array: np.ndarray = reader.as_numpy()
         x_coords, y_coords = reader.xy_coords()
 
         channels, height, width = array.shape

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -1,13 +1,13 @@
 """
 Test I/O on GeoTIFF files.
 """
+
 import os
 import tempfile
 import urllib.request
 
 import numpy as np
 import pytest
-
 from cog3pio import CogReader, read_geotiff
 
 
@@ -117,14 +117,14 @@ def test_read_geotiff_unsupported_dtype():
         )
 
 
-def test_CogReader_to_numpy():
+def test_CogReader_as_numpy():
     """
-    Ensure that the CogReader class's `to_numpy` method produces a numpy.ndarray output.
+    Ensure that the CogReader class's `as_numpy` method produces a numpy.ndarray output.
     """
     reader = CogReader(
         path="https://github.com/rasterio/rasterio/raw/1.3.9/tests/data/float32.tif"
     )
-    array = reader.to_numpy()
+    array = reader.as_numpy()
     assert array.shape == (1, 2, 3)  # band, height, width
     np.testing.assert_equal(
         actual=array,

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -79,11 +79,9 @@ impl<R: Read + Seek> CogReader<R> {
         };
 
         // Put image pixel data into an ndarray
-        let array_data: Array3<T> = Array3::from_shape_vec(
-            (num_bands, height as usize, width as usize),
-            image_data.into(),
-        )
-        .map_err(|_| TiffFormatError::InconsistentSizesEncountered)?;
+        let array_data: Array3<T> =
+            Array3::from_shape_vec((num_bands, height as usize, width as usize), image_data)
+                .map_err(|_| TiffFormatError::InconsistentSizesEncountered)?;
 
         Ok(array_data)
     }

--- a/src/io/geotiff.rs
+++ b/src/io/geotiff.rs
@@ -95,8 +95,8 @@ impl<R: Read + Seek> CogReader<R> {
     /// | 1  |   | 0 0 1 | | 1 |
     /// ```
     ///
-    /// where (`x'` and `y'`) are world coordinates, and (`x`, `y) are the pixel's image
-    /// coordinates. Letters a to f represent:
+    /// where (`x'` and `y'`) are world coordinates, and (`x`, `y`) are the pixel's
+    /// image coordinates. Letters a to f represent:
     ///
     /// - `a` - width of a pixel (x-resolution)
     /// - `b` - row rotation (typically zero)

--- a/src/python/adapters.rs
+++ b/src/python/adapters.rs
@@ -60,7 +60,7 @@ impl PyCogReader {
     /// -------
     /// array : np.ndarray
     ///     3D array of shape (band, height, width) containing the GeoTIFF pixel data.
-    fn to_numpy<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
+    fn as_numpy<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let array_data: Array3<f32> = self
             .inner
             .ndarray()
@@ -142,7 +142,7 @@ fn read_geotiff_py<'py>(path: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAr
     let mut reader = PyCogReader::new(path)?;
 
     // Decode TIFF into numpy ndarray
-    let array_data = reader.to_numpy(py)?;
+    let array_data = reader.as_numpy(py)?;
 
     Ok(array_data)
 }

--- a/src/python/adapters.rs
+++ b/src/python/adapters.rs
@@ -71,6 +71,7 @@ impl PyCogReader {
     }
 
     /// Get x and y coordinates as numpy.ndarray
+    #[allow(clippy::type_complexity)]
     fn xy_coords<'py>(
         &mut self,
         py: Python<'py>,

--- a/src/python/adapters.rs
+++ b/src/python/adapters.rs
@@ -151,7 +151,7 @@ fn read_geotiff_py<'py>(path: &str, py: Python<'py>) -> PyResult<Bound<'py, PyAr
 /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
 /// import the module.
 #[pymodule]
-fn cog3pio<'py>(_py: Python, m: &Bound<'py, PyModule>) -> PyResult<()> {
+fn cog3pio(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register Python classes
     m.add_class::<PyCogReader>()?;
     // Register Python functions


### PR DESCRIPTION
Run `cargo clippy --all-targets --all-features` on Continuous Integration on every Pull Request and push to main.

TODO:
- [x] Add clippy lint CI, adapted from https://doc.rust-lang.org/stable/clippy/continuous_integration/github_actions.html
- [x] Fix clippy lints (do after some other refactoring is complete in other PRs):
  - [`clippy::wrong-self-convention`](https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention) - Fixed by renaming `PyCogReader::to_numpy` method to `PyCogReader::as_numpy` ( :warning: somewhat breaking change ), done in commit ef4cc712217e7748af0cfb63f30d825e576fac03 and e5a9af2931beacdfea00c1dfe2e1ba98dde967af
  - `clippy::type-complexity` - Silenced in commit 9b220bc1823dd246584061dbd1ecb98e63fdbe51
  - `clippy::needless-lifetimes` - fixed in commit b1f8782871eee843035a557592547f4ce83eafa3
  - `clippy::useless-conversion` - fixed in commit b1785190fe311b26c00c422df186af61ffdbc710