### PR TITLE
:lock: Add zizmor to statically analyze GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 # Run linters
 #
-# Lint Rust code using cargo clippy. Apply static analysis rules to catch common
-# mistakes and improves code style.
+# Lint Rust code using cargo clippy, and GitHub Actions workflows using zizmor. Apply
+# static analysis rules to catch common mistakes and improves code style.
 
 name: Lint
 
@@ -23,7 +23,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features
+
+  zizmor:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor .


### PR DESCRIPTION
Using [zizmor](https://github.com/woodruffw/zizmor) to find common security issues in typical GitHub Actions CI/CD setups

References:
- https://woodruffw.github.io/zizmor/usage/#use-in-github-actions