### PR TITLE
:pushpin: Pin MSRV to 1.78.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
+          - 1.78.0 # msrv
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "cog3pio"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+rust-version = "1.78.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
Set minimum supported Rust version (MSRV) to 1.78.0, verified using `cargo msrv find`. Output from `cargo msrv list`:

```
 [Meta]   cargo-msrv 0.18.3

  ╭────────┬────────────────────────────────────────────────────────────────────────────────╮
  │ MSRV   │ Dependency                                                                     │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.78.0 │ cog3pio                                                                        │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.75.0 │ geo                                                                            │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.73.0 │ bumpalo                                                                        │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.70.0 │ geographiclib-rs, geo-types                                                    │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.65.0 │ addr2line                                                                      │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.63.0 │ tokio, pyo3, numpy, tokio-macros, socket2, pyo3-macros, pyo3-ffi, pyo3-build-c │
  │        │ onfig, reqwest, rstar, pyo3-macros-backend, hyper-rustls, h2, hashbrown, rayon │
  │        │ , indexmap, rayon-core                                                         │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.62.1 │ object_store                                                                   │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.61.0 │ tiff, jpeg-decoder, ring, chrono, syn, rustls, memchr, sct, rustls-webpki, cro │
  │        │ ssbeam-deque, crossbeam-epoch                                                  │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.60.0 │ num-traits, once_cell, log, object, rustls-native-certs, windows-targets, giml │
  │        │ i, security-framework, windows_x86_64_msvc, windows_x86_64_gnullvm, windows_x8 │
  │        │ 6_64_gnu, windows_i686_msvc, windows_i686_gnu, windows_aarch64_msvc, windows_a │
  │        │ arch64_gnullvm, ahash, zerocopy, byteorder, crossbeam-utils, zerocopy-derive   │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.57.0 │ web-sys, wasm-bindgen-futures, wasm-bindgen, js-sys, wasm-bindgen-macro, wasm- │
  │        │ bindgen-macro-support, wasm-bindgen-shared, wasm-bindgen-backend               │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.56.0 │ url, indoc, tracing, serde_json, quick-xml, futures, async-trait, quote, proc- │
  │        │ macro2, windows-sys, tracing-core, tracing-attributes, serde_derive, tokio-uti │
  │        │ l, tokio-rustls, futures-util, httpdate, futures-channel, futures-task, future │
  │        │ s-executor, heck, schannel, futures-macro, windows-core                        │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.53.0 │ cc                                                                             │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.51.0 │ percent-encoding, idna, form_urlencoded                                        │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.49.0 │ ndarray, http, parking_lot_core, lock_api                                      │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.48.0 │ windows-sys, base64                                                            │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.43.1 │ itertools                                                                      │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.38.0 │ spin                                                                           │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.37.0 │ pin-project-lite                                                               │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.36.0 │ ryu, itoa, futures-core, either, futures-sink, futures-io, itertools           │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.34.0 │ portable-atomic                                                                │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.31.0 │ serde, num-integer, unicode-ident, syn, slab                                   │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ 1.6.0  │ equivalent                                                                     │
  ├────────┼────────────────────────────────────────────────────────────────────────────────┤
  │        │ bytes, num_cpus, mio, libc, backtrace, weezl, flate2, unindent, memoffset, wal │
  │        │ kdir, snafu, rand, parking_lot, hyper, humantime, rustc-hash, num-complex, lib │
  │        │ m, autocfg, rawpointer, matrixmultiply, spade, robust, i_overlay, float_next_a │
  │        │ fter, earcutr, unicode-normalization, unicode-bidi, windows-targets, hermit-ab │
  │        │ i, wasi, rustc-demangle, miniz_oxide, cfg-if, crc32fast, target-lexicon, winap │
  │        │ i-util, same-file, snafu-derive, doc-comment, untrusted, getrandom, winreg, wa │
  │        │ sm-streams, tower-service, system-configuration, sync_wrapper, serde_urlencode │
  │        │ d, rustls-pemfile, mime, ipnet, http-body, encoding_rs, rand_core, rand_chacha │
  │        │ , want, httparse, iana-time-zone, android-tzdata, smallvec, heapless, i_tree,  │
  │        │ i_shape, i_key_sort, i_float, approx, tinyvec, windows_x86_64_msvc, windows_x8 │
  │        │ 6_64_gnullvm, windows_x86_64_gnu, windows_i686_msvc, windows_i686_gnu, windows │
  │        │ _aarch64_msvc, windows_aarch64_gnullvm, adler, winapi, heck, system-configurat │
  │        │ ion-sys, core-foundation, bitflags, openssl-probe, fnv, pin-utils, ppv-lite86, │
  │        │  redox_syscall, scopeguard, try-lock, iana-time-zone-haiku, core-foundation-sy │
  │        │ s, android_system_properties, allocator-api2, stable_deref_trait, hash32, tiny │
  │        │ vec_macros, winapi-x86_64-pc-windows-gnu, winapi-i686-pc-windows-gnu, security │
  │        │ -framework-sys, version_check                                                  │
  ╰────────┴────────────────────────────────────────────────────────────────────────────────╯
```

Note that MSRV is at 1.78.0 instead of 1.75.0 because lock file is at version 4, which requires Rust 1.78.0

```
Compatibility Check #1: Rust 1.75.0
  [FAIL]   Is incompatible

  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse lock file at: /home/user/projects/cog3pio/Cargo.lock                                                │
  │                                                                                                                                     │
  │ Caused by:                                                                                                                          │
  │   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated? │
  │                                                                                                                                     │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```