### PR TITLE
:arrow_up: SPEC 0: Bump min version to Python 3.12, NumPy 2.0, xarray 2023.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
             python3 -m venv .venv
             .venv/bin/pip3 install -U pip pytest
             .venv/bin/pip3 install cog3pio --find-links dist --force-reinstall
-            pytest --verbose
+            .venv/bin/pytest --verbose
 
   windows:
     runs-on: windows-2025

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,12 @@ jobs:
             apt update
             apt install -y --no-install-recommends \
                         gcc g++ gfortran libopenblas-dev liblapack-dev ninja-build \
-                        pkg-config python3-pip python3-dev
-            pip3 install -U pip pytest
+                        pkg-config python3-pip python3-dev python3-venv
           run: |
             set -e
-            pip3 install cog3pio --find-links dist --force-reinstall
+            python3 -m venv .venv
+            .venv/bin/pip3 install -U pip pytest
+            .venv/bin/pip3 install cog3pio --find-links dist --force-reinstall
             pytest --verbose
 
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Build wheels
         uses: PyO3/maturin-action@60d11847b29f81ca5375519a8eb33cc336ba4bfa # v1.41.0
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           architecture: ${{ matrix.target }}
 
       - name: Build wheels
@@ -149,7 +149,7 @@ jobs:
 
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Build wheels
         uses: PyO3/maturin-action@60d11847b29f81ca5375519a8eb33cc336ba4bfa # v1.41.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,10 @@ jobs:
 
       - name: pytest
         if: ${{ !startsWith(matrix.target, 'x86') && matrix.target != 'ppc64' }}
-        uses: uraimo/run-on-arch-action@4141da824ffb5eda88d221d9cf835f6a61ed98d9 # v3.0.0
+        uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu22.04
+          distro: ubuntu24.04
           githubToken: ${{ github.token }}
           install: |
             apt update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ndarray = "0.15.6"
 num-traits = "0.2.19"
 numpy = "0.25.0"
 object_store = { version = "0.9.0", features = ["http"] }
-pyo3 = { version = "0.25.0", features = ["abi3-py310", "extension-module"] }
+pyo3 = { version = "0.25.0", features = ["abi3-py312", "extension-module"] }
 tiff = { git = "https://github.com/image-rs/image-tiff.git", version = "0.9.1", rev = "0c54a18e2130bd8e3e897009e1fb59eaaf607c6c" }  # https://github.com/image-rs/image-tiff/pull/224
 tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
 url = "2.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cog3pio"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "numpy>=1.23",
-    "xarray>=2022.6.0",
+    "numpy>=2.0",
+    "xarray>=2023.12.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Following [SPEC0](https://scientific-python.org/specs/spec-0000/) policy, though a little ahead of time (using what's suggested for 2025 Q4). Minimum versions updates:

- Python from 3.10 to 3.12
- NumPy from 1.23 to 2.0
- Xarray from 2022.6.0 to 2023.12.0