### PR TITLE
:construction_worker: Run aarch64 CI tests on ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,16 @@ jobs:
         run: cargo test --verbose
 
   linux:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.platform.runner || 'ubuntu-24.04' }}
     strategy:
       matrix:
-        target: [x86_64, aarch64, armv7, s390x, ppc64le]
+        platform:
+          - target: x86_64
+          - target: aarch64
+            runner: ubuntu-24.04-arm
+          - target: armv7
+          - target: s390x
+          - target: ppc64le
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -63,20 +69,20 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@60d11847b29f81ca5375519a8eb33cc336ba4bfa # v1.41.0
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          container: ghcr.io/rust-cross/manylinux_2_28-cross:${{ matrix.target }}
+          container: ghcr.io/rust-cross/manylinux_2_28-cross:${{ matrix.platform.target }}
           sccache: "true"
           manylinux: "2_28"
 
       - name: Upload wheels
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels-linux-${{ matrix.target }}
+          name: wheels-linux-${{ matrix.platform.target }}
           path: dist
 
       - name: pytest
-        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        if: ${{ endswith(matrix.platform.target, '64') }} # x86_64 and aarch64
         shell: bash
         run: |
           set -e
@@ -84,10 +90,10 @@ jobs:
           pytest --verbose
 
       - name: pytest
-        if: ${{ !startsWith(matrix.target, 'x86') && matrix.target != 'ppc64' }}
+        if: ${{ !endswith(matrix.platform.target, '64') }} # armv7, s390x and ppc64le
         uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         with:
-          arch: ${{ matrix.target }}
+          arch: ${{ matrix.platform.target }}
           distro: ubuntu24.04
           githubToken: ${{ github.token }}
           install: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
 
       - name: pytest
         if: ${{ !startsWith(matrix.target, 'x86') && matrix.target != 'ppc64' }}
-        uses: uraimo/run-on-arch-action@4141da824ffb5eda88d221d9cf835f6a61ed98d9 # v3.0.0
+        uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu22.04
+          distro: ubuntu24.04
           githubToken: ${{ github.token }}
           install: |
             apt update


### PR DESCRIPTION
Run CI tests for aarch64 target natively on ubuntu-24.04-arm GitHub Actions runner.

Matrix build syntax adapted from https://github.com/messense/typst-py/pull/78