### PR TITLE
:boom: Read into DLPack tensor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.78.0 # msrv
+          - 1.85.0 # msrv
           - stable
           - beta
           - nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -157,8 +157,9 @@ name = "cog3pio"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "dlpark",
  "geo",
- "ndarray",
+ "ndarray 0.15.6",
  "num-traits",
  "numpy",
  "object_store",
@@ -218,6 +219,18 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "dlpark"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bdac5087071c9178f952a5bcc7a996ff667c1d0c256f23d6512b59fd3dc39d"
+dependencies = [
+ "bitflags 2.9.1",
+ "ndarray 0.16.1",
+ "pyo3",
+ "snafu 0.8.6",
+]
 
 [[package]]
 name = "doc-comment"
@@ -829,6 +842,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,7 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
 dependencies = [
  "libc",
- "ndarray",
+ "ndarray 0.15.6",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -913,7 +941,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.7.5",
  "tokio",
  "tracing",
  "url",
@@ -978,6 +1006,15 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1233,7 +1270,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1411,7 +1448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
  "doc-comment",
- "snafu-derive",
+ "snafu-derive 0.7.5",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
+dependencies = [
+ "snafu-derive 0.8.6",
 ]
 
 [[package]]
@@ -1424,6 +1470,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,6 @@ dependencies = [
  "dlpark",
  "geo",
  "ndarray",
- "num-traits",
  "numpy",
  "object_store",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "bytes",
  "dlpark",
  "geo",
- "ndarray 0.15.6",
+ "ndarray",
  "num-traits",
  "numpy",
  "object_store",
@@ -227,7 +227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bdac5087071c9178f952a5bcc7a996ff667c1d0c256f23d6512b59fd3dc39d"
 dependencies = [
  "bitflags 2.9.1",
- "ndarray 0.16.1",
+ "ndarray",
  "pyo3",
  "snafu 0.8.6",
 ]
@@ -830,19 +830,6 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
@@ -901,7 +888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
 dependencies = [
  "libc",
- "ndarray 0.15.6",
+ "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -1260,9 +1247,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bytes = "1.5.0"
+dlpark = { version = "0.6.0", features = ["ndarray", "pyo3"] }
 geo = "0.29.0"
 ndarray = "0.15.6"
 num-traits = "0.2.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 bytes = "1.5.0"
 dlpark = { version = "0.6.0", features = ["ndarray", "pyo3"] }
 geo = "0.29.0"
-ndarray = "0.15.6"
+ndarray = "0.16.1"
 num-traits = "0.2.19"
 numpy = "0.25.0"
 object_store = { version = "0.9.0", features = ["http"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "cog3pio"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
-rust-version = "1.78.0"
+rust-version = "1.85.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ bytes = "1.5.0"
 dlpark = { version = "0.6.0", features = ["ndarray", "pyo3"] }
 geo = "0.29.0"
 ndarray = "0.16.1"
-num-traits = "0.2.19"
 numpy = "0.25.0"
 object_store = { version = "0.9.0", features = ["http"] }
 pyo3 = { version = "0.25.0", features = ["abi3-py312", "extension-module"] }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Yet another attempt at creating a GeoTIFF reader, in Rust, with Python bindings.
 
 ### Rust
 
+#### Ndarray
+
 ```rust
 use std::io::Cursor;
 
@@ -60,6 +62,43 @@ async fn main() {
 }
 ```
 
+#### DLPack
+
+```rust
+use std::io::Cursor;
+
+use bytes::Bytes;
+use cog3pio::io::geotiff::CogReader;
+use dlpark::ffi::DataType;
+use dlpark::prelude::TensorView;
+use dlpark::SafeManagedTensorVersioned;
+use object_store::path::Path;
+use object_store::{parse_url, GetResult, ObjectStore};
+use tokio;
+use url::Url;
+
+#[tokio::main]
+async fn main() {
+    let cog_url: &str =
+        "https://github.com/cogeotiff/rio-tiler/raw/7.8.0/tests/fixtures/cog_dateline.tif";
+    let tif_url: Url = Url::parse(cog_url).unwrap();
+    let (store, location): (Box<dyn ObjectStore>, Path) = parse_url(&tif_url).unwrap();
+
+    let stream: Cursor<Bytes> = {
+        let result: GetResult = store.get(&location).await.unwrap();
+        let bytes: Bytes = result.bytes().await.unwrap();
+        Cursor::new(bytes)
+    };
+
+    // Read GeoTIFF into a dlpark::versioned::SafeManagedTensorVersioned
+    let mut cog = CogReader::new(stream).unwrap();
+    let tensor: SafeManagedTensorVersioned = cog.dlpack().unwrap();
+    assert_eq!(tensor.shape(), [1, 2355, 2325]);
+    assert_eq!(tensor.data_type(), &DataType::U16);
+}
+```
+
+
 ### Python
 
 #### NumPy
@@ -83,17 +122,19 @@ import xarray as xr
 
 # Read GeoTIFF into an xarray.DataArray
 dataarray: xr.DataArray = xr.open_dataarray(
-    filename_or_obj="https://github.com/cogeotiff/rio-tiler/raw/6.4.1/tests/fixtures/cog_nodata_nan.tif",
+    filename_or_obj="https://github.com/cogeotiff/rio-tiler/raw/7.8.0/tests/fixtures/cog_dateline.tif",
     engine="cog3pio",
 )
-assert dataarray.sizes == {'band': 1, 'y': 549, 'x': 549}
-assert dataarray.dtype == "float32"
+assert dataarray.sizes == {'band': 1, 'y': 2355, 'x': 2325}
+assert dataarray.dtype == "uint16"
 ```
 
 > [!NOTE]
-> Currently, the Python library supports reading single or multi-band GeoTIFF files into
-> a float32 array only, i.e. other dtypes (e.g. uint16) don't work yet. There is support
-> for reading into different dtypes in the Rust crate via a turbofish operator though!
+> The cog3pio python library's `read_geotiff` function supports reading single or
+> multi-band GeoTIFF files into a float32 array only. If you wish to read into other
+> dtypes (e.g. uint16), please use `xarray.open_dataarray` with `engine="cog3pio"`, or
+> use the cog3pio Rust crate's `read_geotiff` function which supports reading into
+> different dtypes via a turbofish operator!
 
 
 ## Roadmap
@@ -108,7 +149,7 @@ Medium term (Q2-Q4 2024):
 - [x] Integration with `xarray` as a
       [`BackendEntrypoint`](https://docs.xarray.dev/en/v2024.02.0/internals/how-to-add-new-backend.html)
 - [x] Implement single-band GeoTIFF reader for multiple dtypes (uint/int/float) (based
-      on [`geotiff`](https://github.com/georust/geotiff) crate, Rust-only)
+      on [`geotiff`](https://github.com/georust/geotiff) crate)
 
 Longer term (2025):
 - [ ] Parallel reader (TBD on multi-threaded or asynchronous)
@@ -117,7 +158,8 @@ Longer term (2025):
 
 ## Related crates
 
-- https://github.com/developmentseed/aiocogeo-rs
+- https://github.com/developmentseed/async-tiff
+- https://github.com/feefladder/tiff2
 - https://github.com/georust/geotiff
 - https://github.com/jblindsay/whitebox-tools
 - https://github.com/pka/georaster

--- a/python/cog3pio/xarray_backend.py
+++ b/python/cog3pio/xarray_backend.py
@@ -29,10 +29,10 @@ class Cog3pioBackendEntrypoint(BackendEntrypoint):
         # other backend specific keyword arguments
         # `chunks` and `cache` DO NOT go here, they are handled by xarray
     ) -> xr.Dataset:
-        reader = CogReader(path=filename_or_obj)
+        cog = CogReader(path=filename_or_obj)
 
-        array: np.ndarray = reader.as_numpy()
-        x_coords, y_coords = reader.xy_coords()
+        array: np.ndarray = np.from_dlpack(cog)
+        x_coords, y_coords = cog.xy_coords()
 
         channels, height, width = array.shape
         dataarray: xr.DataArray = xr.DataArray(

--- a/python/tests/test_io_geotiff.py
+++ b/python/tests/test_io_geotiff.py
@@ -117,14 +117,19 @@ def test_read_geotiff_unsupported_dtype():
         )
 
 
-def test_CogReader_as_numpy():
+def test_CogReader_to_dlpack():
     """
-    Ensure that the CogReader class's `as_numpy` method produces a numpy.ndarray output.
+    Ensure that the CogReader class's `__dlpack__` method produces a dl_tensor that
+    can be read into a numpy.ndarray.
     """
-    reader = CogReader(
+    cog = CogReader(
         path="https://github.com/rasterio/rasterio/raw/1.3.9/tests/data/float32.tif"
     )
-    array = reader.as_numpy()
+
+    assert hasattr(cog, "__dlpack__")
+    assert hasattr(cog, "__dlpack_device__")
+    array = np.from_dlpack(cog)
+
     assert array.shape == (1, 2, 3)  # band, height, width
     np.testing.assert_equal(
         actual=array,


### PR DESCRIPTION
Open up `CogReader` struct as public API with a new `dlpack` method to read from GeoTIFFs into a DLPack tensor! Corresponding PyCogReader struct/class has some new `__dlpack__` and `__dlpack_device__` methods conforming to the [Python specification of DLPack](https://dmlc.github.io/dlpack/latest/python_spec.html#python-specification-for-dlpack) (part of the  [Python array API standard](https://data-apis.org/array-api/latest/index.html)). 

Usage:

```rust
use std::io::Cursor;

use bytes::Bytes;
use cog3pio::io::geotiff::CogReader;
use dlpark::ffi::DataType;
use dlpark::prelude::TensorView;
use dlpark::SafeManagedTensorVersioned;
use object_store::path::Path;
use object_store::{parse_url, GetResult, ObjectStore};
use tokio;
use url::Url;

#[tokio::main]
async fn main() {
    let cog_url: &str =
        "https://github.com/cogeotiff/rio-tiler/raw/7.8.0/tests/fixtures/cog_dateline.tif";
    let tif_url: Url = Url::parse(cog_url).unwrap();
    let (store, location): (Box<dyn ObjectStore>, Path) = parse_url(&tif_url).unwrap();

    let stream: Cursor<Bytes> = {
        let result: GetResult = store.get(&location).await.unwrap();
        let bytes: Bytes = result.bytes().await.unwrap();
        Cursor::new(bytes)
    };

    // Read GeoTIFF into a dlpark::versioned::SafeManagedTensorVersioned
    let mut cog = CogReader::new(stream).unwrap();
    let tensor: SafeManagedTensorVersioned = cog.dlpack().unwrap();
    assert_eq!(tensor.shape(), [1, 2355, 2325]);
    assert_eq!(tensor.data_type(), &DataType::U16);
}
```

Changes:
- [x] Replace `CogReader`'s `ndarray` method with `dlpack` method
- [x] Replace `PyCogReader`'s `as_numpy` method with `__dlpack__` and `__dlpack_device__` methods
- [x] Refactored internals of `read_geotiff` functions to do `TIFF` -> `DLPack` -> `(Py)Array3`, while keeping backwards compatibility
- [x] Updated main README.md with:
  - [x] New Rust example showing how to read a uint16 GeoTIFF into `dlpark::versioned::SafeManagedTensorVersioned`
  - [x] Update Python example showing how to read uint16 GeoTIFF into `xarray.DataArray` object.

References:
- https://dmlc.github.io/dlpack/latest/index.html