### PR TITLE
:construction_worker: Adjust CI workflow conditions for release trigger

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,6 @@ on:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:
-  release:
-    types: [published]
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           pytest --verbose
 
       - name: pytest
-        if: ${{ !endswith(matrix.platform.target, '64') }} # armv7, s390x and ppc64le
+        if: ${{ !endswith(matrix.platform.target, '64') && !startsWith(github.ref, 'refs/tags/') }} # armv7, s390x and ppc64le
         uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         with:
           arch: ${{ matrix.platform.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    if: github.repository == 'weiji14/cog3pio' && (github.event_name == 'release' && (github.event.action == 'prereleased' || github.event.action == 'released'))
+    if: ${{ github.event_name == 'release' && github.event.action == 'prereleased' }}
     needs: [linux, windows, macos, sdist]
     runs-on: ubuntu-24.04
     environment:
@@ -264,7 +264,7 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/project/cog3pio/
-    if: github.repository == 'weiji14/cog3pio' && (github.event_name == 'release' && github.event.action == 'released')
+    if: ${{ github.event_name == 'release' && github.event.action == 'released' }}
     needs: [linux, windows, macos, sdist]
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted OIDC publishing


### PR DESCRIPTION
Release [v0.0.1b1](https://github.com/weiji14/cog3pio/releases/tag/v0.0.1b1) didn't work exactly as planned, as the job to upload to TestPyPI was skipped. Trying to adjust the GitHub Actions workflow syntax before another attempt.

Changes:
- [x] Skip pytest on release for armv7/s390x/ppc64le, 2 hours is too long to wait!
- [x] Disable codspeed benchmark workflow on release events, since it failed at https://github.com/weiji14/cog3pio/actions/runs/15769434761
- [x] Simplify TestPyPI and PyPI upload if-condition triggers