### PR TITLE
:bookmark: Changelog entry for v0.0.1b3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "cog3pio"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "bytes",
  "dlpark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cog3pio"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85.0"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 
 ### <!-- 5 --> 🧰 Maintenance
 
+- 👷 Upload to TestPyPI on prerelease and release tags ([#40](https://github.com/weiji14/cog3pio/pull/40))
 - 👷 Adjust CI workflow conditions for release trigger ([#38](https://github.com/weiji14/cog3pio/pull/38))
 - 🔧 Configure readthedocs documentation build ([#36](https://github.com/weiji14/cog3pio/pull/36))
 - 👷 Build free-threaded wheels on CI and upload to TestPyPI ([#34](https://github.com/weiji14/cog3pio/pull/34))


### PR DESCRIPTION
Third beta release of cog3pio (Python-only).

**Preview** at https://cog3pio--41.org.readthedocs.build/en/41/changelog.html

Changelog made by following these steps:

1. Run [`git-cliff`](https://git-cliff.org) to generate a draft changelog, grouped into different sections based on gitmoji tags.
2. Manually edit `docs/changelog.md` to pick highlights, and combine some dependency update entries.

May this third time be the charm after two failed upload attempts to TestPyPI in #39 and #37. Again, will only release for Python and not the Rust crate, because one of our Cargo dependencies (`image-tiff`) is still a git version rather than a stable version on crates.io.