### PR TITLE
:loud_sound: Enable verbose logging for pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
+          verbose: true
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
@@ -277,3 +278,5 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          verbose: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ commit_preprocessors = [
     { pattern = ':heavy_minus_sign:', replace = "➖" },
     { pattern = ':heavy_plus_sign:', replace = "➕" },
     { pattern = ':lock:', replace = "🔒️" },
+    { pattern = ':loud_sound:', replace = "🔊|" },
     { pattern = ':memo:', replace = "📝" },
     { pattern = ':pushpin:', replace = "📌" },
     { pattern = ':recycle:', replace = "♻️" },
@@ -121,7 +122,7 @@ commit_parsers = [
     { message = "^(🐛|:bug:)", group = "<!-- 2 --> 🐛 Bug Fixes" },
     { message = "^(♻️|:recycle:|🚚|:truck:|🎨|:art:)", group = "<!-- 3 --> 🏭 Refactors" },
     { message = "^(📝|:memo:)", group = "<!-- 4 --> 📝 Documentation" },
-    { message = "^(👷|:construction_worker:|🔧|:wrench:|⬆️|:arrow_up:|➕|:heavy_plus_sign:|➖|:heavy_minus_sign:|⬇️|:arrow_down:|📌|:pushpin:|🔒️|:lock:|🚨|:rotating_light:|🌱|:seedling:)", group = "<!-- 5 --> 🧰 Maintenance" },
+    { message = "^(👷|:construction_worker:|🔧|:wrench:|⬆️|:arrow_up:|➕|:heavy_plus_sign:|➖|:heavy_minus_sign:|⬇️|:arrow_down:|📌|:pushpin:|🔒️|:lock:|🚨|:rotating_light:|🌱|:seedling:|🔊|:loud_sound:)", group = "<!-- 5 --> 🧰 Maintenance" },
 ]
 # filter out the commits that are not matched by commit parsers
 filter_commits = false


### PR DESCRIPTION
Set verbose mode, to see why upload to TestPyPI fails with `HTTPError: 400 Bad Request from https://test.pypi.org/legacy/` seen at https://github.com/weiji14/cog3pio/actions/runs/15773372537/job/44568926023#step:3:246.