### PR TITLE
:pushpin: Unpin sphinx-ext-mystmd in docs extras

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -14,6 +14,8 @@ build:
   jobs:
     install:
       - pip install .[docs]
+      # https://github.com/jupyter-book/sphinx-ext-mystmd/pull/2
+      - pip install --ignore-installed git+https://github.com/weiji14/sphinx-ext-mystmd@e995908b3a898b9c9d5d3fec4ff1478f1f4c1ccd
       - pip list
     post_install:
       - npm install -g mystmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ docs = [
     "myst_parser",
     "sphinx",
     # https://github.com/jupyter-book/sphinx-ext-mystmd/pull/2
-    "sphinx-ext-mystmd @ git+https://github.com/weiji14/sphinx-ext-mystmd@e995908b3a898b9c9d5d3fec4ff1478f1f4c1ccd",
+    # "sphinx-ext-mystmd @ git+https://github.com/weiji14/sphinx-ext-mystmd@e995908b3a898b9c9d5d3fec4ff1478f1f4c1ccd",
+    "sphinx-ext-mystmd",
 ]
 tests = [
     "pytest",


### PR DESCRIPTION
Need to use an official PyPI released version in pyproject.toml, but still installing from https://github.com/jupyter-book/sphinx-ext-mystmd/pull/2 in the docs/.readthedocs.yml file.

Fixes https://github.com/weiji14/cog3pio/pull/43#issuecomment-2994762810, patches #35.