### PR TITLE
:bookmark: Changelog entry for v0.0.1b5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "cog3pio"
-version = "0.0.1-beta.4"
+version = "0.0.1-beta.5"
 dependencies = [
  "bytes",
  "dlpark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cog3pio"
-version = "0.0.1-beta.4"
+version = "0.0.1-beta.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85.0"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 
 ### <!-- 5 --> 🧰 Maintenance
 
+- 📌 Unpin sphinx-ext-mystmd in docs extras ([#44](https://github.com/weiji14/cog3pio/pull/44))
 - 🔊 Enable verbose logging for pypa/gh-action-pypi-publish ([#42](https://github.com/weiji14/cog3pio/pull/42))
 - 👷 Upload to TestPyPI on prerelease and release tags ([#40](https://github.com/weiji14/cog3pio/pull/40))
 - 👷 Adjust CI workflow conditions for release trigger ([#38](https://github.com/weiji14/cog3pio/pull/38))


### PR DESCRIPTION
Fifth beta release of cog3pio (Python-only).

**Preview** at https://cog3pio--45.org.readthedocs.build/en/45/changelog.html

Changelog made by following these steps:

1. Run [`git-cliff`](https://git-cliff.org) to generate a draft changelog, grouped into different sections based on gitmoji tags.
2. Manually edit `docs/changelog.md` to pick highlights, and combine some dependency update entries.

Please let this work, after four failed upload attempts to TestPyPI in #43, #41, #39 and #37!! Again, will only release for Python and not the Rust crate, because one of our Cargo dependencies (`image-tiff`) is still a git version rather than a stable version on crates.io.