### PR TITLE
:memo: Move installation and example commands into separate pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,6 @@ Cloud-optimized GeoTIFF ... Parallel I/O
 Yet another attempt at creating a GeoTIFF reader, in Rust, with Python bindings.
 
 
-## Installation
-
-### Rust
-
-    cargo add --git https://github.com/weiji14/cog3pio.git
-
-### Python
-
-    pip install git+https://github.com/weiji14/cog3pio.git
-
-> [!TIP]
-> The API for this crate/library is still unstable and subject to change, so you may
-> want to pin to a specific git commit using either:
-> - `cargo add --git https://github.com/weiji14/cog3pio.git --rev <sha>`
-> - `pip install git+https://github.com/weiji14/cog3pio.git@<sha>`
->
-> where `<sha>` is a commit hashsum obtained from
-> https://github.com/weiji14/cog3pio/commits/main
-
-
 ## Usage
 
 ### Rust

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
 # ⚙️ *cog3pio* - Cloud-optimized GeoTIFF ... Parallel I/O
 
 *Practice the Three Acts of CoGnizance - Use GeoTIFF-tiles, Be GDAL-less, Go GPU-accelerated*
-
-[API Reference](api.html) | [Changelog](changelog.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,26 @@
 # ⚙️ *cog3pio* - Cloud-optimized GeoTIFF ... Parallel I/O
 
 *Practice the Three Acts of CoGnizance - Use GeoTIFF-tiles, Be GDAL-less, Go GPU-accelerated*
+
+## Installation
+
+### Rust
+
+```bash
+cargo add --git https://github.com/weiji14/cog3pio.git
+```
+
+### Python
+
+```bash
+pip install git+https://github.com/weiji14/cog3pio.git
+```
+
+> [!TIP]
+> The API for this crate/library is still unstable and subject to change, so you may
+> want to pin to a specific git commit using either:
+> - `cargo add --git https://github.com/weiji14/cog3pio.git --rev <sha>`
+> - `pip install git+https://github.com/weiji14/cog3pio.git@<sha>`
+>
+> where `<sha>` is a commit hashsum obtained from
+> https://github.com/weiji14/cog3pio/commits/main

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -16,6 +16,11 @@ project:
 
 site:
   template: book-theme
+  nav:
+    - title: 📖 API Reference
+      url: /api.html
+    - title: 📆 Changelog
+      url: /changelog.html
   options:
     hide_toc: true
     hide_footer_links: true


### PR DESCRIPTION
Doing a final tidy up of the documentation pages before the v0.0.1 release.

TODO:
- [x] Put "API Reference" and "Changelog" in top-level navbar
- [x] Move installation instructions from main README.md to `docs/index.md` (displayed on readthedocs)
- [ ] Move Rust example code from main README.md to `src/lib.rs` (displayed on docs.rs)
- [ ] Move Python example code from main README.md to `docs/index.md` (displayed on readthedocs)