### PR TITLE
:bug: Fix Cargo.toml metadata description to enable crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "cog3pio"
 version = "0.0.1"
 edition = "2024"
+description = "Cloud-optimized GeoTIFF ... Parallel I/O"
+readme = "README.md"
+repository = "https://github.com/weiji14/cog3pio"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85.0"
 authors = ["Wei Ji <23487320+weiji14@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Yet another attempt at creating a GeoTIFF reader, in Rust, with Python bindings.
 2025 Q1-Q2:
 - [x] Support for [`DLPack`](https://dmlc.github.io/dlpack/latest/index.html) protocol
       (through [`dlpark`](https://crates.io/crates/dlpark))
-- [ ] Initial release on crates.io and PyPI
+- [x] Initial release on crates.io and PyPI
 
 2025 Q3-Q4:
 - [ ] GPU-based decoding (via [`nvTIFF`](https://crates.io/crates/nvtiff-sys))


### PR DESCRIPTION
Patch the metadata in Cargo.toml to ensure publish to crates.io works next time. Also marking initial release to crates.io/PyPI as done on roadmap.

Fixes https://github.com/weiji14/cog3pio/pull/50#issuecomment-3015066054