### PR TITLE
:mag: Add shield badges to main README.md

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -66,6 +66,7 @@ commit_preprocessors = [
     { pattern = ':heavy_plus_sign:', replace = "➕" },
     { pattern = ':lock:', replace = "🔒️" },
     { pattern = ':loud_sound:', replace = "🔊" },
+    { pattern = ':mag:', replace = "🔍️" },
     { pattern = ':memo:', replace = "📝" },
     { pattern = ':pushpin:', replace = "📌" },
     { pattern = ':recycle:', replace = "♻️" },
@@ -83,7 +84,7 @@ commit_parsers = [
     { message = "^(✨|:sparkles:)", group = "<!-- 1 --> ✨ Features" },
     { message = "^(🐛|:bug:)", group = "<!-- 2 --> 🐛 Bug Fixes" },
     { message = "^(♻️|:recycle:|🚚|:truck:|🎨|:art:)", group = "<!-- 3 --> 🏭 Refactors" },
-    { message = "^(📝|:memo:)", group = "<!-- 4 --> 📝 Documentation" },
+    { message = "^(📝|:memo:|🔍️|:mag:)", group = "<!-- 4 --> 📝 Documentation" },
     { message = "^(👷|:construction_worker:|🔧|:wrench:|⬆️|:arrow_up:|➕|:heavy_plus_sign:|➖|:heavy_minus_sign:|⬇️|:arrow_down:|📌|:pushpin:|🔒️|:lock:|🚨|:rotating_light:|🌱|:seedling:|🔊|:loud_sound:)", group = "<!-- 5 --> 🧰 Maintenance" },
 ]
 # sort the commits inside sections by oldest/newest order

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # cog3pio
 
+[![docs.rs](https://img.shields.io/docsrs/cog3pio?label=docs.rs%20latest)](https://docs.rs/cog3pio)
+[![crates.io](https://img.shields.io/crates/v/cog3pio)](https://crates.io/crates/cog3pio)
+[![Latest version on PyPI](https://img.shields.io/pypi/v/cog3pio)](https://pypi.org/project/cog3pio)
+[![Latest version on conda-forge](https://img.shields.io/conda/v/conda-forge/cog3pio)](https://anaconda.org/conda-forge/cog3pio)
+[![Digital Object Identifier for the Zenodo archive](https://zenodo.org/badge/DOI/10.5281/15702154.svg)](https://doi.org/10.5281/zenodo.15702154)
+
 Cloud-optimized GeoTIFF ... Parallel I/O
 
 Yet another attempt at creating a GeoTIFF reader, in Rust, with Python bindings.


### PR DESCRIPTION
Included badges to docs.rs, crates.io, pypi, conda-forge and zenodo.

Also update installation instructions to include conda-forge option.