### PR TITLE
:memo: Use clean urls on readthedocs with jupyter-book v2.0.0b2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,3 @@ pip install cog3pio
 >
 > where `<sha>` is a commit hashsum obtained from
 > https://github.com/weiji14/cog3pio/commits/main
-
-## User Guide
-
-[Quickstart](quickstart.html) | [API Reference](api.html) | [Changelog](changelog.html)

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -18,7 +18,5 @@ project:
 site:
   template: book-theme
   options:
-    hide_toc: true
-    hide_footer_links: true
     # favicon: favicon.ico
     # logo: site_logo.png

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Notes:
 
 ## PyCapsule (DLPack)
 
-Read a GeoTIFF file from a HTTP url via the [`CogReader`](api#dlpack) class into an
+Read a GeoTIFF file from a HTTP url via the [`CogReader`](../api#dlpack) class into an
 object that conforms to the
 [Python Specification for DLPack](https://dmlc.github.io/dlpack/latest/python_spec.html),
 whereby the `__dlpack__()` method returns a
@@ -44,7 +44,7 @@ assert array.dtype == "float16"
 
 ## Xarray
 
-Read GeoTIFF file from a HTTP url via the [`Cog3pioBackendEntrypoint`](api#xarray)
+Read GeoTIFF file from a HTTP url via the [`Cog3pioBackendEntrypoint`](../api#xarray)
 engine into an `xarray.DataArray` object (akin to
 [`rioxarray`](https://corteva.github.io/rioxarray)).
 
@@ -62,7 +62,7 @@ assert dataarray.dtype == "uint16"
 
 ## NumPy
 
-Read a GeoTIFF file from a HTTP url via the [`read_geotiff`](api#numpy) function
+Read a GeoTIFF file from a HTTP url via the [`read_geotiff`](../api#numpy) function
 into a `numpy.ndarray` (akin to [`rasterio`](https://rasterio.readthedocs.io)).
 
 ```python

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Notes:
 
 ## PyCapsule (DLPack)
 
-Read a GeoTIFF file from a HTTP url via the [`CogReader`](api.html#dlpack) class into an
+Read a GeoTIFF file from a HTTP url via the [`CogReader`](api#dlpack) class into an
 object that conforms to the
 [Python Specification for DLPack](https://dmlc.github.io/dlpack/latest/python_spec.html),
 whereby the `__dlpack__()` method returns a
@@ -44,7 +44,7 @@ assert array.dtype == "float16"
 
 ## Xarray
 
-Read GeoTIFF file from a HTTP url via the [`Cog3pioBackendEntrypoint`](api.html#xarray)
+Read GeoTIFF file from a HTTP url via the [`Cog3pioBackendEntrypoint`](api#xarray)
 engine into an `xarray.DataArray` object (akin to
 [`rioxarray`](https://corteva.github.io/rioxarray)).
 
@@ -62,7 +62,7 @@ assert dataarray.dtype == "uint16"
 
 ## NumPy
 
-Read a GeoTIFF file from a HTTP url via the [`read_geotiff`](api.html#numpy) function
+Read a GeoTIFF file from a HTTP url via the [`read_geotiff`](api#numpy) function
 into a `numpy.ndarray` (akin to [`rasterio`](https://rasterio.readthedocs.io)).
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ benchmark = [
     "rioxarray",
 ]
 docs = [
-    "jupyter-book>=2.0.0a0",
+    "jupyter-book>=2.0.0b2",
     "myst_parser",
     "sphinx",
     # https://github.com/jupyter-book/sphinx-ext-mystmd/pull/2


### PR DESCRIPTION
Jupyter-book 2.0.0b2 uses mystmd 1.6.0 which should allow for clean links on Readthedocs, so we can revert a bunch of hacks pointing to `*.html` pages.

**Preview** at https://cog3pio--53.org.readthedocs.build/en/53/

<img width="1541" height="1083" alt="image" src="https://github.com/user-attachments/assets/b5548117-3b61-4d70-8b56-26e0d55df681" />

TODO:
- [x] Put toc navigation links back on left sidebar, since clean url links work now, i.e. revert afcceeab31659d4a429baf8fd11405b609b7e6b9 in #36
- [x] Update links to API documented classes/functions, i.e. partially revert 274183a308a466ff07020849c310696f9f3c6194 in #50