### PR TITLE
:construction_worker: Update CI versions and set concurrency limits

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
           cargo codspeed build
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # v4.11.1
+        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v4.15.0
         with:
           mode: simulation
           run: cargo codspeed run
@@ -106,7 +106,7 @@ jobs:
 
       # Run the benchmark tests
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # v4.11.1
+        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v4.15.0
         with:
           mode: simulation
           run: python -m pytest --verbose --codspeed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
@@ -343,6 +343,6 @@ jobs:
           merge-multiple: true
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   rust:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: rust-${{ matrix.toolchain }}-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     strategy:
       matrix:
         toolchain:
@@ -176,7 +179,7 @@ jobs:
   windows:
     runs-on: windows-2025
     concurrency:
-      group: windows-${{ matrix.platform.target }}-${{ github.workflow }}-${{ github.ref }}
+      group: windows-${{ matrix.target }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     strategy:
       matrix:
@@ -283,6 +286,9 @@ jobs:
 
   sdist:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: sdist-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -306,6 +312,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [linux, windows, macos, sdist]
     runs-on: ubuntu-24.04
+    concurrency:
+      group: testpypi-${{ github.ref }}
+      cancel-in-progress: true
     environment:
       name: testpypi
       url: https://test.pypi.org/project/cog3pio
@@ -328,6 +337,9 @@ jobs:
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
     runs-on: ubuntu-24.04
+    concurrency:
+      group: pypi-${{ github.ref }}
+      cancel-in-progress: true
     environment:
       name: pypi
       url: https://pypi.org/project/cog3pio/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           pip install cog3pio --no-index --no-deps --find-links dist --force-reinstall -vv
-          pip install cog3pio --prefer-binary --group tests
+          pip install cog3pio --prefer-binary pytest # --group tests
           pytest --verbose
         env:
           PIP_EXTRA_INDEX_URL: ${{ matrix.platform.target == 'riscv64' && 'https://gitlab.com/api/v4/projects/56254198/packages/pypi/simple/' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           mirror: "https://raw.githubusercontent.com/riseproject-dev/python-versions/main"
 
       - name: Build wheels
-        uses: PyO3/maturin-action@3f475a463fd27ce2440c13988f39fd1312dc9381
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --locked --compatibility pypi --features ${{ matrix.platform.feat-flags || 'pyo3' }} --out dist --interpreter python3.13
@@ -153,7 +153,7 @@ jobs:
 
       - name: pytest
         if: ${{ !endswith(matrix.platform.target, '64') && !startsWith(github.ref, 'refs/tags/') }} # armv7, s390x and ppc64le
-        uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+        uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
         with:
           arch: ${{ matrix.platform.target }}
           distro: ubuntu_devel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,10 @@ on:
     types: [opened, reopened, synchronize]
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 # Make sure CI fails on all warnings, including Clippy lints

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup rust toolchain, cache and cargo-docs-rs binary
-        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           channel: nightly
           bins: cargo-docs-rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
       # Patch nvtiff.h (v0.7.0) to add missing enum tag
       - export CONDA_PREFIX="$CONDA_ENVS_PATH/$CONDA_DEFAULT_ENV";
         unset CONDA_DEFAULT_ENV;
-        mamba env update --prefix "$CONDA_PREFIX" --file docs/environment.yml;
+        mamba create --prefix "$CONDA_PREFIX" --file docs/environment.yml;
         mamba list;
         sed --in-place "s/nvtiffTagDataType type/enum nvtiffTagDataType type/g" $CONDA_PREFIX/include/nvtiff.h
     install:

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -6,9 +6,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-26.04"
   tools:
-    python: "mambaforge-23.11"
+    python: "miniforge3-25.11"
     rust: "1.91"
   jobs:
     create_environment:


### PR DESCRIPTION
Various CI version updates in `.readthedocs.yml` and `.github/workflows/*.yml` files, and set concurrency limits for all GitHub Actions workflows.

References:
- https://docs.zizmor.sh/audits/#concurrency-limits
- https://cambridge-iccs.github.io/green-ci/best_practices.html#concurrency